### PR TITLE
build: download.dfinity.systems openssl-static-binaries is deprecated

### DIFF
--- a/ic.json
+++ b/ic.json
@@ -2,36 +2,36 @@
   "replica": {
     "commit": "69e1408347723dbaa7a6cd2faa9b65c42abbe861",
     "sha256": "120iinjcybvc346wf1iq6r964a3w5dhhif6rnf2ngf0q3350rlrc",
-    "url": "https://download.dfinity.systems/ic/{commit}/openssl-static-binaries/x86_64-linux/replica.gz"
+    "url": "https://download.dfinity.systems/ic/{commit}/binaries/x86_64-linux/replica.gz"
   },
   "ic-starter": {
     "commit": "69e1408347723dbaa7a6cd2faa9b65c42abbe861",
     "sha256": "1ddgxd9pnybnjiqhgggxlkbq8ml99ca4iq54kh221kdj7h1m334d",
     "repo": "https://github.com/dfinity/ic/tree/master/rs/starter",
-    "url": "https://download.dfinity.systems/ic/{commit}/openssl-static-binaries/x86_64-linux/ic-starter.gz"
+    "url": "https://download.dfinity.systems/ic/{commit}/binaries/x86_64-linux/ic-starter.gz"
   },
   "canister_sandbox": {
     "commit": "69e1408347723dbaa7a6cd2faa9b65c42abbe861",
     "sha256": "04r9rs47ky6715jwia5qzpj5983y2xyg246wncjhybqn79a9m10i",
     "repo": "https://github.com/dfinity/ic/tree/master/rs/canister_sandbox",
-    "url": "https://download.dfinity.systems/ic/{commit}/openssl-static-binaries/x86_64-linux/canister_sandbox.gz"
+    "url": "https://download.dfinity.systems/ic/{commit}/binaries/x86_64-linux/canister_sandbox.gz"
   },
   "sandbox_launcher": {
     "commit": "69e1408347723dbaa7a6cd2faa9b65c42abbe861",
     "sha256": "0zzpr02vc14ibx1qzd31a9jzh1zhb7ahcg85fazs6jkjk2zidi4n",
     "repo": "https://github.com/dfinity/ic/tree/master/rs/canister_sandbox/sandbox_launcher",
-    "url": "https://download.dfinity.systems/ic/{commit}/openssl-static-binaries/x86_64-linux/sandbox_launcher.gz"
+    "url": "https://download.dfinity.systems/ic/{commit}/binaries/x86_64-linux/sandbox_launcher.gz"
   },
   "icx-proxy": {
     "commit": "69e1408347723dbaa7a6cd2faa9b65c42abbe861",
     "sha256": "105jm3px6ky88jc86am8dkxz1vnhzcxy0p7skzs98baylr96kzrb",
     "repo": "https://github.com/dfinity/ic/tree/master/rs/boundary_node/icx_proxy",
-    "url": "https://download.dfinity.systems/ic/{commit}/openssl-static-binaries/x86_64-linux/icx-proxy-dev.gz"
+    "url": "https://download.dfinity.systems/ic/{commit}/binaries/x86_64-linux/icx-proxy-dev.gz"
   },
   "ic-https-outcalls-adapter": {
     "commit": "69e1408347723dbaa7a6cd2faa9b65c42abbe861",
     "sha256": "0qgxzfzym8gh91bsg5krmlrh39anlcgnff330w4jgiwql95ayvr7",
     "repo": "https://github.com/dfinity/ic/tree/master/rs/https_outcalls/adapter",
-    "url": "https://download.dfinity.systems/ic/{commit}/openssl-static-binaries/x86_64-linux/ic-https-outcalls-adapter.gz"
+    "url": "https://download.dfinity.systems/ic/{commit}/binaries/x86_64-linux/ic-https-outcalls-adapter.gz"
   }
 }


### PR DESCRIPTION
Follow-up https://github.com/junobuild/juno-docker/pull/4#discussion_r1484058547