### PR TITLE
feat: ship admin server with satellite

### DIFF
--- a/docker/start
+++ b/docker/start
@@ -11,6 +11,4 @@ node ./cli/dist/index.js start --port "$PORT" --state "$STATE_CLI_DIR/modules.js
 
 node ./cli/dist/index.js watch --port "$PORT" --state "$STATE_CLI_DIR/modules.json" &
 
-if [ "$CLI_BUILD" == "console" ]; then
-  node ./cli/dist/index.js admin --port "$PORT" --state "$STATE_CLI_DIR/modules.json" --admin-port "$ADMIN_PORT"
-fi
+node ./cli/dist/index.js admin --port "$PORT" --state "$STATE_CLI_DIR/modules.json" --admin-port "$ADMIN_PORT"


### PR DESCRIPTION
It's useful for satellite developer to be able to transfer ICP from the ledger as well using the admin server

e.g.

```
curl "http://localhost:5999/ledger/transfer/?to=$PRINCIPAL"
```
