### PR TITLE
feat: no snapshots

### DIFF
--- a/cli/src/services/modules.services.ts
+++ b/cli/src/services/modules.services.ts
@@ -70,7 +70,8 @@ const installCode = async ({
     mode,
     canisterId: Principal.from(canisterId),
     wasmModule,
-    arg: new Uint8Array(arg ?? EMPTY_ARG)
+    arg: new Uint8Array(arg ?? EMPTY_ARG),
+    takeSnapshot: false
   });
 };
 


### PR DESCRIPTION
We do not need to backup when developing locally since we are constantly updating WASMs.
For the console it also lead to a race condition on cold start because it tries to backup and empty canister.