### PR TITLE
feat: create a base juno docker image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,13 +1,41 @@
-name: Build Docker Image
+name: Build Docker Images
 
 on:
   workflow_dispatch:
   pull_request:
 
 jobs:
-  build:
+  build-base:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Build the Docker image
-        run: docker build . --file Dockerfile
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Build Base Docker Image
+        run: docker build -t junobuild/base -f Dockerfile.base .
+
+      - name: Cache Base Image
+        run: docker save junobuild/base | gzip > juno-base.tar.gz
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: juno-base
+          path: juno-base.tar.gz
+
+  build-main:
+    runs-on: ubuntu-latest
+    needs: build-base
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Restore Cached Base Image
+        uses: actions/download-artifact@v4
+        with:
+          name: juno-base
+
+      - name: Load Base Image
+        run: docker load < juno-base.tar.gz
+
+      - name: Build Main Docker Image
+        run: docker build -t junobuild/satellite -f Dockerfile .

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,9 +5,42 @@ on:
     types: [published]
 
 jobs:
-  push_to_registry:
+  push_base:
+    name: Push Base Docker Image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: junobuild/base
+          tags: |
+            type=semver,pattern={{major}}
+            type=semver,pattern={{version}}
+
+      - name: Build and push Base Image (`junobuild/base`)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          file: ./Dockerfile.base
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  push_main:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
+    needs: push_base
     strategy:
       matrix:
         include:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,6 @@
-FROM ubuntu:24.04
+FROM junobuild/juno-base:latest
 
-LABEL repository="https://github.com/junobuild/juno-docker"
-LABEL homepage="https://juno.build"
-LABEL maintainer="David Dal Busco <david.dalbusco@outlook.com>"
-
-ENV TZ=UTC
-
-# Install required tools
-RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y \
-    jq \
-    curl \
-    liblmdb-dev \
-    libunwind-dev \
-    netcat-traditional \
-    ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install NodeJS
-RUN curl -sL https://deb.nodesource.com/setup_22.x | bash -
-RUN apt-get install nodejs -y
-
-# Create and use a user instead of using root
-RUN useradd -ms /bin/bash apprunner
+# Use a user instead of using root. User was created in base.
 USER apprunner
 
 # Define working directories

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM junobuild/juno-base:latest
+FROM junobuild/base:latest
 
 # Use a user instead of using root. User was created in base.
 USER apprunner

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -20,6 +20,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y \
 RUN curl -sL https://deb.nodesource.com/setup_22.x | bash -
 RUN apt-get install nodejs=22.14.0-1nodesource1 -y
 
+RUN node --version
+RUN npm --version
+
 # Create and use a user instead of using root
 RUN useradd -ms /bin/bash apprunner
 USER apprunner

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,34 @@
+FROM --platform=linux/amd64 ubuntu@sha256:bbf3d1baa208b7649d1d0264ef7d522e1dc0deeeaaf6085bf8e4618867f03494
+
+LABEL repository="https://github.com/junobuild/juno-docker"
+LABEL homepage="https://juno.build"
+LABEL maintainer="David Dal Busco <david.dalbusco@outlook.com>"
+
+ENV TZ=UTC
+
+# Install required tools
+RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y \
+    jq \
+    curl \
+    liblmdb-dev \
+    libunwind-dev \
+    netcat-traditional \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install NodeJS
+RUN curl -sL https://deb.nodesource.com/setup_22.x | bash -
+RUN apt-get install nodejs=22.14.0-1nodesource1 -y
+
+# Create and use a user instead of using root
+RUN useradd -ms /bin/bash apprunner
+USER apprunner
+
+# Set script directory
+WORKDIR /usr/local/bin/juno-scripts
+
+# Copy common build scripts
+COPY --chown=apprunner:apprunner ./base/bootstrap ./base/build-canister /usr/local/bin/juno-scripts/
+
+# Ensure scripts are executable
+RUN chmod +x /usr/local/bin/juno-scripts/bootstrap /usr/local/bin/juno-scripts/build-canister

--- a/base/bootstrap
+++ b/base/bootstrap
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# install build dependencies (rustup + ic-wasm)
+
+set -euo pipefail
+
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPTS_DIR/.."
+
+function run() {
+    1>&2 echo "running $@"
+    rc=0 && "$@" || rc="$?"
+    if ! [ "$rc" -eq 0 ]
+    then
+        1>&2 echo "Bootstrap command failed: $@"
+        exit "$rc"
+    fi
+}
+
+rust_version=$(cat ./rust-toolchain.toml | sed -n 's/^channel[[:space:]]*=[[:space:]]"\(.*\)"/\1/p')
+echo "using rust version '$rust_version'"
+
+targets=$(sed -n 's/^targets[[:space:]]*=[[:space:]]\[\(.*\)\]/\1/p' ./rust-toolchain.toml | tr -d '[]" ' | tr ',' ' ')
+echo "using rust targets: $targets"
+
+# Install rustup with a toolchain set to 'none'.
+# Note: rustup does NOT automatically pick up ./rust-toolchain.toml. We will install and set the correct version afterwards.
+# https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html
+run curl --fail https://sh.rustup.rs -sSf | run sh -s -- -y --default-toolchain "none" --no-modify-path
+
+# Install the effective Rust version
+run rustup toolchain install "$rust_version"
+run rustup default "$rust_version"
+
+echo "Rust toolchain version $(rustc --version) installed."
+
+# Install Rust targets
+for target in $targets; do
+    run rustup target add "$target"
+done
+
+echo "looking for ic-wasm 0.8.5"
+if [[ ! "$(command -v ic-wasm)" || "$(ic-wasm --version)" != "ic-wasm 0.8.5" ]]
+then
+    echo "installing ic-wasm 0.8.5"
+    run cargo install ic-wasm --version 0.8.5 --locked
+fi
+
+echo "installing candid-extractor"
+cargo install candid-extractor --locked
+
+echo "installing wasi2ic"
+cargo install wasi2ic --locked
+
+# make sure the packages are actually installed (rustup waits for the first invoke to lazyload)
+cargo --version
+cargo clippy --version
+cargo fmt --version

--- a/base/build-canister
+++ b/base/build-canister
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+# Builds a single canister
+function build_canister() {
+    local canister=$1
+    local src_root_dir=$2
+    local output_dir=$3
+    local only_deps=$4
+    local with_certification=$5
+    local build_type=$6
+    local target=$7
+    shift 7
+    local extra_build_args=("$@")
+
+    if [ -z "$canister" ]; then
+        echo "ERROR: No canister specified."
+        exit 1
+    fi
+
+    if [ -z "$src_root_dir" ]; then
+        echo "ERROR: No root directory for the source specified."
+        exit 1
+    fi
+
+    if [ -z "$output_dir" ]; then
+        echo "ERROR: No output directory specified."
+        exit 1
+    fi
+
+    if [ ! -d "$output_dir" ]; then
+        echo "ERROR: The output directory '$output_dir' does not exist."
+        exit 1
+    fi
+
+    TARGET="wasm32-unknown-unknown"
+
+    case "$target" in
+        wasm32-wasip1)
+            TARGET="wasm32-wasip1"
+            USE_WASI=1
+            ;;
+        wasm32-unknown-unknown | "")
+            USE_WASI=0
+            ;;
+        *)
+            echo "ERROR: Invalid target specified. Use 'wasm32' (default) or 'wasi'."
+            exit 1
+            ;;
+    esac
+
+    # Checking for installed additional tools
+    if [ "$only_deps" != "1" ]; then
+      check_tools "$TARGET"
+    fi
+
+    echo "Building $canister"
+    echo
+
+    SRC_DIR="$src_root_dir/$canister"
+
+    # Standardize source references
+    CARGO_HOME="${CARGO_HOME:-"$HOME/.cargo"}"
+
+    # Flags required by third party dependencies such as getrandom
+    FEATURES="--cfg getrandom_backend=\"custom\""
+
+    RUSTFLAGS="--remap-path-prefix $CARGO_HOME=/cargo -C link-args=-zstack-size=3000000 $FEATURES"
+
+    cargo_build_args=(
+        --manifest-path "$SRC_DIR/Cargo.toml"
+        --target "$TARGET"
+        --release
+        --locked
+        -j1
+        )
+    # XXX: for bash > 4.4, empty arrays are considered unset, so do some substitution
+    cargo_build_args+=(${extra_build_args[@]+"${extra_build_args[@]}"})
+
+    echo Running cargo build "${cargo_build_args[@]}"
+    echo RUSTFLAGS: "$RUSTFLAGS"
+    echo
+
+    RUSTFLAGS="$RUSTFLAGS" cargo build "${cargo_build_args[@]}"
+
+    if [ "$only_deps" != "1" ]
+    then
+      CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$PWD/target}"
+
+      if [ "$USE_WASI" -eq 1 ]; then
+          echo
+          echo "Converting WASI to IC..."
+          wasi2ic "$CARGO_TARGET_DIR/$TARGET/release/$canister.wasm" "$CARGO_TARGET_DIR/$TARGET/release/$canister.wasm" --quiet
+      fi
+
+      # Optimize WASM and set metadata
+      ic-wasm \
+          "$CARGO_TARGET_DIR/$TARGET/release/$canister.wasm" \
+          -o "$output_dir/$canister.wasm" \
+          shrink \
+          --keep-name-section
+
+      # adds the content of $canister.did to the `icp:public candid:service` custom section of the public metadata in the wasm
+      ic-wasm "$output_dir/$canister.wasm" -o "$output_dir/$canister.wasm" metadata candid:service -f "$SRC_DIR/$canister.did" -v public --keep-name-section
+
+      if [ -n "$build_type" ]
+      then
+        # add the type of build "stock" to the satellite. This way, we can identify whether it's the standard canister ("stock") or a custom build ("extended") of the developer.
+        ic-wasm "$output_dir/$canister.wasm" -o "$output_dir/$canister.wasm" metadata juno:build -d "$build_type" -v public --keep-name-section
+      fi
+
+      if [ "$with_certification" -eq 1 ]
+      then
+        # indicate support for certificate version 1 and 2 in the canister metadata
+        ic-wasm "$output_dir/$canister.wasm" -o "$output_dir/$canister.wasm" metadata supported_certificate_versions -d "1,2" -v public --keep-name-section
+      fi
+
+      # --no-name to avoid reproducibility issues
+      # --keep-unused in CI Docker build, but useful for local tooling and particularly for the job that generates the DID files
+      gzip --no-name --force --keep "$output_dir/$canister.wasm"
+    fi
+}
+
+function check_tools() {
+  local target=$1
+
+  if [[ ! "$(command -v ic-wasm)" || "$(ic-wasm --version)" != "ic-wasm 0.8.5" ]]
+  then
+      echo "could not find ic-wasm 0.8.5"
+      echo "ic-wasm version 0.8.5 is needed, please run the following command:"
+      echo "  cargo install ic-wasm --version 0.8.5"
+      exit 1
+  fi
+
+  if [ "$target" = "wasm32-wasip1" ]; then
+      if [[ ! "$(command -v wasi2ic)" || "$(wasi2ic --version)" != "wasi2ic 0.2.14" ]]; then
+          echo "could not find wasi2ic 0.2.14"
+          echo "wasi2ic version 0.2.14 is needed, please run the following command:"
+          echo "  cargo install wasi2ic --version 0.2.14"
+          exit 1
+      fi
+  fi
+}


### PR DESCRIPTION
This way we can pin Ubuntu in https://github.com/junobuild/juno-docker and https://github.com/junobuild/juno plus we can use the same build scripts for rust wasm.