### PR TITLE
build: pin Ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu@sha256:72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782
 
 LABEL repository="https://github.com/junobuild/juno-docker"
 LABEL homepage="https://juno.build"


### PR DESCRIPTION
We want to pin and use the same version of Ubuntu as in Juno main repo.

https://github.com/junobuild/juno/pull/1373