### PR TITLE
feat: replace fsWatch by chokidar

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -29,6 +29,7 @@
         "@junobuild/console": "^0.1.5",
         "@junobuild/storage": "^0.1.5",
         "atomically": "^2.0.3",
+        "chokidar": "^4.0.3",
         "kleur": "^4.1.5",
         "semver": "^7.7.1"
       },
@@ -2252,6 +2253,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/cli-cursor": {
@@ -5139,6 +5155,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -45,6 +45,7 @@
     "@junobuild/console": "^0.1.5",
     "@junobuild/storage": "^0.1.5",
     "atomically": "^2.0.3",
+    "chokidar": "^4.0.3",
     "kleur": "^4.1.5",
     "semver": "^7.7.1"
   },

--- a/cli/src/watch/services/_watcher.ts
+++ b/cli/src/watch/services/_watcher.ts
@@ -1,5 +1,5 @@
 import {debounce} from '@dfinity/utils';
-import type {FileChangeInfo} from 'fs/promises';
+import {basename} from 'node:path';
 import type {CliContext} from '../../types/context';
 import type {WatcherDescription} from '../../types/watcher';
 
@@ -13,13 +13,9 @@ export abstract class Watcher {
     this.moduleFileName = moduleFileName;
   }
 
-  onWatch = async ({
-    $event: {filename},
-    context
-  }: {
-    $event: FileChangeInfo<string>;
-    context: CliContext;
-  }) => {
+  onWatch = async ({filePath, context}: {filePath: string; context: CliContext}) => {
+    const filename = basename(filePath);
+
     if (filename !== this.moduleFileName) {
       return;
     }


### PR DESCRIPTION
On one hand, there was an issue when re-adding .wasm or .mjs files to the /target/deploy folder—those changes weren’t detected. Deleting a file and then adding it again, even if the build was different, didn’t trigger a new deploy.

On the other hand, there was also a strange issue: if an exception occurred in a watcher, the watcher would stop entirely, even though the errors were properly caught. This was problematic, as developers had to restart their environment to build and deploy again.

Long story short, using Chokidar resolved both issues.