### PR TITLE
feat: read banner instead of package.json

### DIFF
--- a/cli/src/constants/dev.constants.ts
+++ b/cli/src/constants/dev.constants.ts
@@ -33,7 +33,7 @@ export const JUNO_DEV_CONFIG_FILENAME = 'juno.dev.config'; // .json | .js | .cjs
 export const DEV_KIT_FOLDER = join(process.cwd(), 'kit');
 
 export const DEV_SPUTNIK_MJS_FILENAME = 'sputnik.index.mjs';
+export const DEV_SPUTNIK_MJS_FILE_PATH = join(DEV_DEPLOY_FOLDER, DEV_SPUTNIK_MJS_FILENAME);
+
 export const DEV_BUILD_SPUTNIK = join(DEV_KIT_FOLDER, 'build', 'build-sputnik-with-mjs');
 export const DEV_PREPARE_PKG_SPUTNIK = join(DEV_KIT_FOLDER, 'build', 'prepare-sputnik-package');
-
-export const DEV_SPUTNIK_PACKAGE_JSON = join(DEV_DEPLOY_FOLDER, 'sputnik.package.json');

--- a/cli/src/services/sputnik.services.ts
+++ b/cli/src/services/sputnik.services.ts
@@ -1,10 +1,14 @@
-import {isEmptyString, isNullish} from '@dfinity/utils';
+import {isEmptyString, isNullish, nonNullish} from '@dfinity/utils';
 import {execute, type PackageJson} from '@junobuild/cli-tools';
+import {readFileSync} from 'atomically';
+import kleur from 'kleur';
 import {
   DEV_BUILD_SPUTNIK,
   DEV_PREPARE_PKG_SPUTNIK,
   DEV_SPUTNIK_MJS_FILE_PATH
 } from '../constants/dev.constants';
+
+const {red} = kleur;
 
 export const buildSputnik = async () => {
   const {success} = await generateMetadata();
@@ -19,7 +23,13 @@ export const buildSputnik = async () => {
 };
 
 const generateMetadata = async (): Promise<{success: boolean}> => {
-  const metadata = await buildMetadata();
+  const {result: metadata, err} = await buildMetadata();
+
+  if (nonNullish(err)) {
+    console.log(red('️‼️  Error reading metadata.'));
+    console.log(err);
+    return {success: false};
+  }
 
   if (isNullish(metadata?.name) || isEmptyString(metadata.name)) {
     console.log(`⚠️  Missing "name" in package metadata. Aborting build!`);
@@ -41,20 +51,36 @@ const generateMetadata = async (): Promise<{success: boolean}> => {
   return {success: true};
 };
 
-const buildMetadata = async (): Promise<
-  Pick<PackageJson, 'name' | 'version'> | undefined | null
-> => {
+const buildMetadata = async (): Promise<{
+  result: Pick<PackageJson, 'name' | 'version'> | undefined | null;
+  err?: unknown;
+}> => {
   try {
-    const {__juno_package__} = await import(DEV_SPUTNIK_MJS_FILE_PATH);
+    const mjs = readFileSync(DEV_SPUTNIK_MJS_FILE_PATH, 'utf-8');
+    const banner = mjs.match(/^\/\/\s*@juno:package\s+({.*})/);
 
-    const {juno, name, version} = __juno_package__;
+    if (isNullish(banner)) {
+      return {
+        result: null,
+        err: new Error(
+          `⚠️  Missing Juno package metadata banner at the top of ${DEV_SPUTNIK_MJS_FILE_PATH}. Aborting build!`
+        )
+      };
+    }
 
-    return {
+    const [_fullMatch, match] = banner;
+    const {juno, name, version} = JSON.parse(match);
+
+    const result = {
       name: juno?.functions?.name ?? name,
       version: juno?.functions?.version ?? version
     };
-  } catch (_err: unknown) {
-    // The build will be skipped.
-    return undefined;
+
+    return {result};
+  } catch (err: unknown) {
+    return {
+      result: undefined,
+      err
+    };
   }
 };

--- a/cli/src/services/sputnik.services.ts
+++ b/cli/src/services/sputnik.services.ts
@@ -1,10 +1,9 @@
 import {isEmptyString, isNullish} from '@dfinity/utils';
-import {execute, type PackageJson, readPackageJson} from '@junobuild/cli-tools';
-import {existsSync} from 'node:fs';
+import {execute, type PackageJson} from '@junobuild/cli-tools';
 import {
   DEV_BUILD_SPUTNIK,
   DEV_PREPARE_PKG_SPUTNIK,
-  DEV_SPUTNIK_PACKAGE_JSON
+  DEV_SPUTNIK_MJS_FILE_PATH
 } from '../constants/dev.constants';
 
 export const buildSputnik = async () => {
@@ -45,21 +44,17 @@ const generateMetadata = async (): Promise<{success: boolean}> => {
 const buildMetadata = async (): Promise<
   Pick<PackageJson, 'name' | 'version'> | undefined | null
 > => {
-  if (!existsSync(DEV_SPUTNIK_PACKAGE_JSON)) {
-    return null;
-  }
-
   try {
-    const {name, version, juno} = await readPackageJson({
-      packageJsonPath: DEV_SPUTNIK_PACKAGE_JSON
-    });
+    const {__juno_package__} = await import(DEV_SPUTNIK_MJS_FILE_PATH);
+
+    const {juno, name, version} = __juno_package__;
 
     return {
       name: juno?.functions?.name ?? name,
       version: juno?.functions?.version ?? version
     };
   } catch (_err: unknown) {
-    // The build will use the build version of Sputnik for the extended build version.
+    // The build will be skipped.
     return undefined;
   }
 };

--- a/cli/src/services/sputnik.services.ts
+++ b/cli/src/services/sputnik.services.ts
@@ -57,7 +57,7 @@ const buildMetadata = async (): Promise<{
 }> => {
   try {
     const mjs = readFileSync(DEV_SPUTNIK_MJS_FILE_PATH, 'utf-8');
-    const banner = mjs.match(/^\/\/\s*@juno:package\s+({.*})/);
+    const banner = /^\/\/\s*@juno:package\s+({.*})/.exec(mjs);
 
     if (isNullish(banner)) {
       return {
@@ -69,7 +69,7 @@ const buildMetadata = async (): Promise<{
     }
 
     const [_fullMatch, match] = banner;
-    const {juno, name, version} = JSON.parse(match);
+    const {juno, name, version}: PackageJson = JSON.parse(match);
 
     const result = {
       name: juno?.functions?.name ?? name,


### PR DESCRIPTION
Having to deal with an extra package.json annoys me, it's not clear and asynchron to have a json and a mjs