### PR TITLE
fix: upload wasm to Console

### DIFF
--- a/cli/src/services/console.services.ts
+++ b/cli/src/services/console.services.ts
@@ -37,7 +37,7 @@ export const installRelease = async ({
     console: CONSOLE
   });
 
-  const filename = `${basename(wasmPath).replace('.wasm.gz', '')}-v${version}.wasm.gz`;
+  const filename = `${basename(wasmPath).replace('.wasm.gz', '').replace('.gz', '')}-v${version}.wasm.gz`;
 
   const fullPath = `/releases/${filename}`;
 


### PR DESCRIPTION
Fix "... does not match the required..." when upload wasm to the Console. This happens because it tries to upload e.g. "orbiter.gz-v1.0.0.wasm.gz".