### PR TITLE
feat: use npm run preview instead of dev

### DIFF
--- a/docker/server/console/setup
+++ b/docker/server/console/setup
@@ -8,4 +8,7 @@ if [ "$CLI_BUILD" == "skylab" ]; then
   # npm error signal SIGILL esbuild because package-lock contains a reference to esbuild arm
   rm ${JUNO_REPO}/package-lock.json
   npm --prefix ${JUNO_REPO} install
+
+  # we use npm run preview to run the console that's why we need to build the application
+  npm --prefix ${JUNO_REPO} run build:skylab
 fi

--- a/docker/server/console/start
+++ b/docker/server/console/start
@@ -5,7 +5,7 @@ source ./.bashrc
 JUNO_REPO="/juno/target/juno-main"
 
 if [ "$CLI_BUILD" == "skylab" ]; then
-  npm --prefix ${JUNO_REPO} run --silent dev:silent -- --port "$CONSOLE_PORT" --host &
+  npm --prefix ${JUNO_REPO} run --silent preview -- --port "$CONSOLE_PORT" --host &
 
   if ./docker/server/wait-port "$CONSOLE_PORT"; then
     echo "🖥️   Console started on port ${CONSOLE_PORT}"


### PR DESCRIPTION
It should be a bit more performant to pre-build the resources and use preview instead of dev to run the Console UI.