### PR TITLE
feat: build watcher should not inherit a module

### DIFF
--- a/cli/src/types/watcher.ts
+++ b/cli/src/types/watcher.ts
@@ -1,12 +1,15 @@
 import type {Module} from '../services/modules.services';
+import type {ModuleDescription} from './module';
 
 export interface WatcherDescription {
   moduleFileName: string;
 }
 
 export type WatcherDeployDescription = {initModule: () => Module} & WatcherDescription;
-export type WatcherConsoleInstallDescription = {
-  key: string;
-  name: string;
-} & WatcherDescription;
-export type WatcherBuildDescription = {build: () => Promise<void>} & WatcherDeployDescription;
+
+export type WatcherJobDescription = Pick<ModuleDescription, 'key' | 'name'> & WatcherDescription;
+
+export type WatcherConsoleInstallDescription = WatcherJobDescription;
+export type WatcherBuildDescription = {
+  build: () => Promise<void>;
+} & WatcherConsoleInstallDescription;

--- a/cli/src/watch/modules/sputnik.ts
+++ b/cli/src/watch/modules/sputnik.ts
@@ -1,10 +1,11 @@
 import {DEV_SPUTNIK_MJS_FILENAME} from '../../constants/dev.constants';
-import {initSatelliteModule} from '../../modules/satellite';
+import {satellite} from '../../modules/satellite';
 import {buildSputnik} from '../../services/sputnik.services';
 import {BuildWatcher} from '../services/build.watcher';
 
 export const sputnikWatcher = new BuildWatcher({
   moduleFileName: DEV_SPUTNIK_MJS_FILENAME,
-  initModule: initSatelliteModule,
+  key: satellite.key,
+  name: satellite.name,
   build: buildSputnik
 });

--- a/cli/src/watch/services/build.watcher.ts
+++ b/cli/src/watch/services/build.watcher.ts
@@ -1,22 +1,19 @@
-import type {Module} from '../../services/modules.services';
 import type {CliContext} from '../../types/context';
-import type {WatcherBuildDescription} from '../../types/watcher';
+import {WatcherBuildDescription} from '../../types/watcher';
 import {Watcher} from './_watcher';
 
 export class BuildWatcher extends Watcher {
-  readonly #initModule: () => Module;
+  readonly #moduleName: string;
   readonly #build: () => Promise<void>;
 
-  constructor({moduleFileName, initModule, build}: WatcherBuildDescription) {
+  constructor({moduleFileName, build, name}: WatcherBuildDescription) {
     super({moduleFileName});
-    this.#initModule = initModule;
+    this.#moduleName = name;
     this.#build = build;
   }
 
   protected async onExec(_params: {context: CliContext}) {
-    const mod = this.#initModule();
-
-    console.log(`🌀  Building ${mod.name}...`);
+    console.log(`🌀  Building ${this.#moduleName}...`);
 
     await this.execute();
   }

--- a/cli/src/watch/services/build.watcher.ts
+++ b/cli/src/watch/services/build.watcher.ts
@@ -1,5 +1,5 @@
 import type {CliContext} from '../../types/context';
-import {WatcherBuildDescription} from '../../types/watcher';
+import type {WatcherBuildDescription} from '../../types/watcher';
 import {Watcher} from './_watcher';
 
 export class BuildWatcher extends Watcher {


### PR DESCRIPTION
A "build watcher" is basically a "static" generator therefore it should not really be aware of the runtime information - i.e. not be aware of what module is deployed or not.

More a phylosophical PR than a that useful one but, it can avoid some recursion in the imports.