### PR TITLE
feat: workaround to mute agent-js warnings

### DIFF
--- a/cli/src/api/agent.api.ts
+++ b/cli/src/api/agent.api.ts
@@ -1,0 +1,27 @@
+import type {HttpAgent, Identity} from '@dfinity/agent';
+import {createAgent as createAgentUtils} from '@dfinity/utils';
+
+export const createAgent = async ({
+  identity,
+  port
+}: {
+  identity: Identity;
+  port: string | undefined;
+}): Promise<HttpAgent> => {
+  // TODO: Workaround for agent-js. Disable console.warn.
+  // See https://github.com/dfinity/agent-js/issues/843
+  // eslint-disable-next-line @typescript-eslint/prefer-destructuring
+  const hideAgentJsConsoleWarn = globalThis.console.warn;
+  globalThis.console.warn = (): null => null;
+
+  try {
+    return await createAgentUtils({
+      identity,
+      host: `http://localhost:${port}`,
+      fetchRootKey: true
+    });
+  } finally {
+    // Redo console.warn
+    globalThis.console.warn = hideAgentJsConsoleWarn;
+  }
+};

--- a/cli/src/modules/cmc/cmc.post-install.ts
+++ b/cli/src/modules/cmc/cmc.post-install.ts
@@ -2,20 +2,21 @@ import {IC_ROOT_KEY, fromHex} from '@dfinity/agent';
 import {IDL} from '@dfinity/candid';
 import {GovernanceCanister, NnsFunction, type MakeProposalRequest} from '@dfinity/nns';
 import {Principal} from '@dfinity/principal';
-import {arrayBufferToUint8Array, createAgent} from '@dfinity/utils';
+import {arrayBufferToUint8Array} from '@dfinity/utils';
+import {createAgent} from '../../api/agent.api';
 import {MAIN_IDENTITY_KEY} from '../../constants/constants';
 import {NEURON_ID} from '../../constants/modules.constants';
 import type {ModuleInstallParams} from '../../types/module';
 
 export const makeAuthorizedSubnetworksProposal = async ({
-  identities
-}: Pick<ModuleInstallParams, 'identities'>) => {
+  identities,
+  port
+}: Pick<ModuleInstallParams, 'identities' | 'port'>) => {
   const {[MAIN_IDENTITY_KEY]: identity} = identities;
 
   const agent = await createAgent({
     identity,
-    host: 'http://127.0.0.1:5987',
-    fetchRootKey: true
+    port
   });
 
   const {makeProposal} = GovernanceCanister.create({

--- a/cli/src/modules/governance/governance.post-install.ts
+++ b/cli/src/modules/governance/governance.post-install.ts
@@ -1,17 +1,19 @@
 import {IDL} from '@dfinity/candid';
 import {GovernanceCanister, NnsFunction, type MakeProposalRequest} from '@dfinity/nns';
-import {createAgent} from '@dfinity/utils';
+import {createAgent} from '../../api/agent.api';
 import {MAIN_IDENTITY_KEY} from '../../constants/constants';
 import {NEURON_ID} from '../../constants/modules.constants';
 import type {ModuleInstallParams} from '../../types/module';
 
-export const makeIcpXdrProposal = async ({identities}: Pick<ModuleInstallParams, 'identities'>) => {
+export const makeIcpXdrProposal = async ({
+  identities,
+  port
+}: Pick<ModuleInstallParams, 'identities' | 'port'>) => {
   const {[MAIN_IDENTITY_KEY]: identity} = identities;
 
   const agent = await createAgent({
     identity,
-    host: 'http://127.0.0.1:5987',
-    fetchRootKey: true
+    port
   });
 
   const {makeProposal} = GovernanceCanister.create({

--- a/cli/src/services/context.services.ts
+++ b/cli/src/services/context.services.ts
@@ -1,4 +1,5 @@
-import {createAgent, isNullish} from '@dfinity/utils';
+import {isNullish} from '@dfinity/utils';
+import {createAgent} from '../api/agent.api';
 import {MAIN_IDENTITY_KEY, MINTER_IDENTITY_KEY} from '../constants/constants';
 import {CliState} from '../states/cli.state';
 import type {CliContext} from '../types/context';
@@ -27,13 +28,13 @@ export const buildContext = async (args?: string[]): Promise<CliContext> => {
 
   const agent = await createAgent({
     identity: mainIdentity,
-    host: `http://localhost:${port}`,
-    fetchRootKey: true
+    port
   });
 
   return {
     identities: {[MAIN_IDENTITY_KEY]: mainIdentity, [MINTER_IDENTITY_KEY]: minterIdentity},
     agent,
-    state
+    state,
+    port
   };
 };

--- a/cli/src/types/context.ts
+++ b/cli/src/types/context.ts
@@ -6,4 +6,5 @@ export interface CliContext {
   identities: {[MAIN_IDENTITY_KEY]: Identity; [MINTER_IDENTITY_KEY]: Identity};
   agent: HttpAgent;
   state: CliState;
+  port: string | undefined;
 }


### PR DESCRIPTION
Relates to https://github.com/dfinity/agent-js/issues/843.

On boot 

```
Expected to find result for path time, but instead found nothing.
juno-skylab-1  |   WR [AgentReadStateError]: Caught exception while attempting to read state: Server returned an error:
juno-skylab-1  |     Code: 503 (Service Unavailable)
juno-skylab-1  |     Body: Replica is unhealthy: CertifiedStateBehind. Check the /api/v2/status for more information.
juno-skylab-1  |   
juno-skylab-1  |       at t.readState (file:///juno/cli/dist/index.js:34:322)
juno-skylab-1  |       at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
juno-skylab-1  |       at async file:///juno/cli/dist/index.js:31:6828
juno-skylab-1  |       at async Promise.all (index 0)
juno-skylab-1  |       at async Object.Rpe [as request] (file:///juno/cli/dist/index.js:31:8313)
juno-skylab-1  |       at async t.syncTime (file:///juno/cli/dist/index.js:34:1688)
juno-skylab-1  |       at async Promise.all (index 0)
juno-skylab-1  |       at async t.create (file:///juno/cli/dist/index.js:31:50500)
juno-skylab-1  |       at async L8 (file:///juno/cli/dist/index.js:57:14402)
juno-skylab-1  |       at async xc (file:///juno/cli/dist/index.js:506:22666) {
juno-skylab-1  |     response: t: Server returned an error:
juno-skylab-1  |       Code: 503 (Service Unavailable)
juno-skylab-1  |       Body: Replica is unhealthy: CertifiedStateBehind. Check the /api/v2/status for more information.
juno-skylab-1  |     
juno-skylab-1  |         at t (file:///juno/cli/dist/index.js:44:322)
juno-skylab-1  |         at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
juno-skylab-1  |         at async t.readState (file:///juno/cli/dist/index.js:31:57254)
juno-skylab-1  |         at async file:///juno/cli/dist/index.js:31:6828
juno-skylab-1  |         at async Promise.all (index 0)
juno-skylab-1  |         at async Object.Rpe [as request] (file:///juno/cli/dist/index.js:31:8313)
juno-skylab-1  |         at async t.syncTime (file:///juno/cli/dist/index.js:34:1688)
juno-skylab-1  |         at async Promise.all (index 0)
juno-skylab-1  |         at async t.create (file:///juno/cli/dist/index.js:31:50500)
juno-skylab-1  |         at async L8 (file:///juno/cli/dist/index.js:57:14402) {
juno-skylab-1  |       response: {
juno-skylab-1  |         ok: false,
juno-skylab-1  |         status: 503,
juno-skylab-1  |         statusText: 'Service Unavailable',
juno-skylab-1  |         headers: [Array]
juno-skylab-1  |       }
juno-skylab-1  |     },
juno-skylab-1  |     requestId: 'undefined',
juno-skylab-1  |     senderPubkey: '',
juno-skylab-1  |     senderSig: '',
juno-skylab-1  |     ingressExpiry: '1744212540000000000'
juno-skylab-1  |   }

```
