### PR TITLE
feat: ignore initial chokidar event for config

### DIFF
--- a/cli/src/watch/_types/watcher.ts
+++ b/cli/src/watch/_types/watcher.ts
@@ -19,4 +19,4 @@ export type WatcherBuildDescription = {
   build: () => Promise<void>;
 } & WatcherConsoleInstallDescription;
 
-export type WatcherConfigDescription = Omit<WatcherDeployDescription, "debounceDelay">;
+export type WatcherConfigDescription = Omit<WatcherDeployDescription, 'debounceDelay'>;

--- a/cli/src/watch/_types/watcher.ts
+++ b/cli/src/watch/_types/watcher.ts
@@ -19,4 +19,4 @@ export type WatcherBuildDescription = {
   build: () => Promise<void>;
 } & WatcherConsoleInstallDescription;
 
-export type WatcherConfigDescription = WatcherDeployDescription;
+export type WatcherConfigDescription = Omit<WatcherDeployDescription, "debounceDelay">;

--- a/cli/src/watch/_watchers/config.watcher.ts
+++ b/cli/src/watch/_watchers/config.watcher.ts
@@ -3,11 +3,13 @@ import type {CliContext} from '../../types/context';
 import type {WatcherConfigDescription} from '../_types/watcher';
 import {Watcher} from './_watcher';
 
+const ON_WATCH_DEBOUNCE_DELAY = 5000;
+
 export class ConfigWatcher extends Watcher {
   readonly #initModule: () => Module;
 
   constructor({moduleFileName, initModule}: WatcherConfigDescription) {
-    super({moduleFileName});
+    super({moduleFileName, debounceDelay: ON_WATCH_DEBOUNCE_DELAY});
     this.#initModule = initModule;
   }
 

--- a/cli/src/watch/config.watch.ts
+++ b/cli/src/watch/config.watch.ts
@@ -67,7 +67,7 @@ const watch = async ({
 
   chokidar
     .watch(configPath, {
-      ignoreInitial: false,
+      ignoreInitial: true,
       awaitWriteFinish: true
     })
     .on('add', watchOnEvent)

--- a/cli/src/watch/config.watch.ts
+++ b/cli/src/watch/config.watch.ts
@@ -15,8 +15,6 @@ import {ConfigWatcher} from './_watchers/config.watcher';
 
 const {red} = kleur;
 
-const ON_WATCH_DEBOUNCE_DELAY = 5000;
-
 export const watchConfig = async (args?: string[]) => {
   await watch({
     args,
@@ -24,8 +22,7 @@ export const watchConfig = async (args?: string[]) => {
     initWatcher: ({moduleFileName}: Pick<WatcherDescription, 'moduleFileName'>): ConfigWatcher =>
       new ConfigWatcher({
         moduleFileName,
-        initModule: initSatelliteModule,
-        debounceDelay: ON_WATCH_DEBOUNCE_DELAY
+        initModule: initSatelliteModule
       })
   });
 };
@@ -37,8 +34,7 @@ export const watchDevConfig = async (args?: string[]) => {
     initWatcher: ({moduleFileName}: Pick<WatcherDescription, 'moduleFileName'>): ConfigWatcher =>
       new ConfigWatcher({
         moduleFileName,
-        initModule: initSatelliteModule,
-        debounceDelay: ON_WATCH_DEBOUNCE_DELAY
+        initModule: initSatelliteModule
       })
   });
 };


### PR DESCRIPTION
We don't want to apply the config twice on boot