### PR TITLE
feat: move console UI start at the end

### DIFF
--- a/docker/server/app
+++ b/docker/server/app
@@ -8,9 +8,9 @@ set -m
 
 ./docker/server/replica/serve &
 
-./docker/server/console/start &
-
 ./docker/server/cli/start
+
+./docker/server/console/start &
 
 # now we bring the primary process back into the foreground
 # and leave it there

--- a/docker/server/app
+++ b/docker/server/app
@@ -8,9 +8,11 @@ set -m
 
 ./docker/server/replica/serve &
 
-./docker/server/cli/start
+./docker/server/cli/wait
 
 ./docker/server/console/start &
+
+./docker/server/cli/start
 
 # now we bring the primary process back into the foreground
 # and leave it there

--- a/docker/server/cli/start
+++ b/docker/server/cli/start
@@ -1,14 +1,9 @@
 #!/usr/bin/env bash
 
-./docker/server/wait-port "$PORT"
-
-# Pinging the icx-proxy and replica ports does not necessarily mean the replica is fully mounted and "healthy" - i.e. ready.
-node ./cli/dist/index.js wait --port "$PORT" --state "$STATE_CLI_DIR/modules.json"
-
 node ./cli/dist/index.js deploy --port "$PORT" --state "$STATE_CLI_DIR/modules.json"
 
 node ./cli/dist/index.js start --port "$PORT" --state "$STATE_CLI_DIR/modules.json"
 
 node ./cli/dist/index.js watch --port "$PORT" --state "$STATE_CLI_DIR/modules.json" &
 
-node ./cli/dist/index.js admin --port "$PORT" --state "$STATE_CLI_DIR/modules.json" --admin-port "$ADMIN_PORT" &
+node ./cli/dist/index.js admin --port "$PORT" --state "$STATE_CLI_DIR/modules.json" --admin-port "$ADMIN_PORT"

--- a/docker/server/cli/start
+++ b/docker/server/cli/start
@@ -11,4 +11,4 @@ node ./cli/dist/index.js start --port "$PORT" --state "$STATE_CLI_DIR/modules.js
 
 node ./cli/dist/index.js watch --port "$PORT" --state "$STATE_CLI_DIR/modules.json" &
 
-node ./cli/dist/index.js admin --port "$PORT" --state "$STATE_CLI_DIR/modules.json" --admin-port "$ADMIN_PORT"
+node ./cli/dist/index.js admin --port "$PORT" --state "$STATE_CLI_DIR/modules.json" --admin-port "$ADMIN_PORT" &

--- a/docker/server/cli/wait
+++ b/docker/server/cli/wait
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+./docker/server/wait-port "$PORT"
+
+# Pinging the icx-proxy and replica ports does not necessarily mean the replica is fully mounted and "healthy" - i.e. ready.
+node ./cli/dist/index.js wait --port "$PORT" --state "$STATE_CLI_DIR/modules.json"

--- a/docker/server/console/start
+++ b/docker/server/console/start
@@ -7,7 +7,7 @@ JUNO_REPO="$JUNO_MAIN_DIR"
 if [ "$CLI_BUILD" == "skylab" ]; then
   npm --prefix "${JUNO_REPO}" run --silent preview -- --port "$CONSOLE_PORT" --host &
 
-  if ./docker/server/wait-port "$CONSOLE_PORT"; then
+  if ./docker/server/wait-port "$CONSOLE_PORT" --silent; then
     echo "🖥️   Console started on port ${CONSOLE_PORT}"
   fi
 fi

--- a/docker/server/wait-port
+++ b/docker/server/wait-port
@@ -2,15 +2,23 @@
 
 #source https://stackoverflow.com/a/70181222/5404186
 
+PORT=$1
+SILENT=false
+
+# Check if --silent is provided as second argument
+if [[ "$2" == "--silent" ]]; then
+    SILENT=true
+fi
+
 for _ in `seq 1 20`; do
-    echo -n .
-    if nc -z localhost $1; then
-        echo "✅ Connection to port $1 succeeded."
+    $SILENT || echo -n .
+    if nc -z localhost "$PORT"; then
+        $SILENT || echo "✅ Connection to port $PORT succeeded."
         exit 0
     fi
     sleep 0.5
 done
 
-echo "❌ Connection to port $1 failed!"
+echo "❌ Connection to port $PORT failed!"
 
 exit 1


### PR DESCRIPTION
Otherwise the log about the fact that the Console UI is mounted is printed at the start and is not noticable.