### PR TITLE
build: integrate Juno source repo pre-release

### DIFF
--- a/docker/download/juno-source
+++ b/docker/download/juno-source
@@ -9,7 +9,7 @@ if [ ! -d "$DIR" ]; then
 fi
 
 # Use a specific commit (optional, or switch to refs/heads/main if needed)
-COMMIT=8be1da4f3f9d477cf5c51e19c9b1a8221ae23b42
+COMMIT=9c42f96920a768afa5a2ea24c038b699c40491d5
 
 curl -L -o "$DIR/juno.tar.gz" https://github.com/junobuild/juno/archive/$COMMIT.tar.gz
 


### PR DESCRIPTION
JS lib is released and documentation is ready (https://github.com/junobuild/docs/pull/385). So to unlock the doc and because the main repo is already ready for release, I integrate the latest version.