### PR TITLE
chore: CI build multi platforms

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,17 @@
 name: Build Docker Image
 
 on:
-  workflow_dispatch:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: "Target platform"
+        required: false
+        default: "linux/amd64"
+        type: choice
+        options:
+          - linux/amd64
+          - linux/arm64
 
 jobs:
   build:
@@ -16,9 +25,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set platform
+        id: platform
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "PLATFORM=${{ github.event.inputs.platform }}" >> $GITHUB_OUTPUT
+          else
+            echo "PLATFORM=linux/amd64" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build the Docker image
         run: |
           docker buildx build \
-            --platform linux/amd64,linux/arm64 \
+            --platform ${{ steps.platform.outputs.PLATFORM }} \
             --file Dockerfile \
             .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,5 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build the Docker image
-        run: docker build . --file Dockerfile
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --file Dockerfile \
+            .


### PR DESCRIPTION
It takes ages, so let's stick to amd64 for PR and add an option to manually build arm64