### PR TITLE
fix: partial latest

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -108,6 +108,7 @@ jobs:
 
             docker buildx imagetools create \
               --tag "$tag" \
+              --force \
               "$arch_tag_amd64" \
               "$arch_tag_arm64"
           done


### PR DESCRIPTION
Latest skylab tag (v0.3.2) was released for arm and amd
https://hub.docker.com/r/junobuild/skylab/tags

But satellite only for amd
https://hub.docker.com/r/junobuild/satellite/tags

And console only for arm
https://hub.docker.com/r/junobuild/console/tags

As a result for example this [job](https://github.com/junobuild/juno/actions/runs/16821787159/job/47650229650) in the console did not find an amd image