### PR TITLE
build: npm i --force for console ui (temporary)

### DIFF
--- a/docker/server/console/setup
+++ b/docker/server/console/setup
@@ -7,7 +7,7 @@ JUNO_REPO="$JUNO_MAIN_DIR"
 if [ "$CLI_BUILD" == "skylab" ]; then
   # npm error signal SIGILL esbuild because package-lock contains a reference to esbuild arm
   rm "${JUNO_REPO}"/package-lock.json
-  npm --prefix "${JUNO_REPO}" install
+  npm --prefix "${JUNO_REPO}" install --force
 
   # we use npm run preview to run the console that's why we need to build the application
   npm --prefix "${JUNO_REPO}" run build:skylab


### PR DESCRIPTION
There is no freaking npm way. As long as the `@dfinity/oisy-wallet-signer` is not released, there is no way to have an installation from scratch with it coliving with `@dfinity/zod-schemas@1.1.0`. Since I need both, because the foundation also uses the Juno libs, which themselves use zod-schema, I have to use force.