### PR TITLE
chore: remove npm i --force when installing skylab

### DIFF
--- a/docker/server/console/setup
+++ b/docker/server/console/setup
@@ -7,7 +7,7 @@ JUNO_REPO="$JUNO_MAIN_DIR"
 if [ "$CLI_BUILD" == "skylab" ]; then
   # npm error signal SIGILL esbuild because package-lock contains a reference to esbuild arm
   rm "${JUNO_REPO}"/package-lock.json
-  npm --prefix "${JUNO_REPO}" install --force
+  npm --prefix "${JUNO_REPO}" install
 
   # we use npm run preview to run the console that's why we need to build the application
   npm --prefix "${JUNO_REPO}" run build:skylab


### PR DESCRIPTION
With pinned typescript and up-to-date libs, `--force` should not be necessary anymore.