### PR TITLE
fix: extend wait-port timeout to 30 seconds and make it configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,11 @@ RUN mkdir -p /juno/.juno/replica
 RUN mkdir /juno/.juno/cli
 VOLUME /juno/.juno
 
-# Exposed ports
+# Exposed ports and timeout
 ENV PORT=5987
 ENV ADMIN_PORT=5999
 ENV CONSOLE_PORT=5866
+ENV PORT_TIMEOUT_SECONDS=30
 
 # Environment variables where files are downloaded and executed
 ENV TARGET_DIR=/juno/target

--- a/docker/server/wait-port
+++ b/docker/server/wait-port
@@ -10,7 +10,10 @@ if [[ "$2" == "--silent" ]]; then
     SILENT=true
 fi
 
-for _ in `seq 1 20`; do
+WAIT_SECONDS="${PORT_TIMEOUT_SECONDS:-30}"
+ATTEMPTS=$(( WAIT_SECONDS * 2 ))
+
+for _ in $(seq 1 $ATTEMPTS); do
     $SILENT || echo -n .
     if nc -z localhost "$PORT"; then
         $SILENT || echo "✅ Connection to port $PORT succeeded."


### PR DESCRIPTION
A developer suddently cannot start new emulator. I'm not entirely sure but based on the last screenshot provided, it seems that the issue is related to the fact that the HTTP Gateway started by PocketIC is not mounted within the 10 seconds timeout waited before starting the CLI.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c846fdbd-e772-4c09-ab3a-35c6f0b65eca" />

The lack of the output `.✅ Connection to port 5987 succeeded.` seems to indicate this issue, assuming there is no issue at mounting the gateway as the developer said they could develop with the emulator previously.

This PR bumps the timeout to 30 seconds and expose the variable as environment. This way we can extend the config and cli for it as well.

For simplicity reasons I'll introduce just one global timeout for what ever ports we mount. Not sure we need that a fine grain at the moment.