### PR TITLE
feat: enable PocketIC incomplete_state

### DIFF
--- a/cli/src/constants/pocket-ic.constants.ts
+++ b/cli/src/constants/pocket-ic.constants.ts
@@ -1,5 +1,6 @@
 import type {
   IcpConfig,
+  IncompleteState,
   InitialTime,
   InstanceHttpGatewayConfig,
   SubnetSpec
@@ -29,3 +30,11 @@ export const INSTANCE_HTTP_GATEWAY: Omit<InstanceHttpGatewayConfig, 'port'> = {
 // Configures the instance to make progress automatically
 // https://github.com/dfinity/ic/blob/master/packages/pocket-ic/src/common/rest.rs#L637
 export const INITIAL_TIME: InitialTime = {AutoProgress: {artificial_delay_ms: null}};
+
+// An additional optional field to specify if incomplete state (e.g., resulting from not deleting a PocketIC instance gracefully) is allowed.
+// The drawback of enabling incomplete state is that messages and their effects on canister state might be lost in an incomplete state.
+// In other words, we might miss the last update calls executed before stopping the emulator but, that's worth the price
+// of not getting a corrupted state if deleting the instance on stop would not complete gracefully.
+// https://github.com/dfinity/ic/blob/master/packages/pocket-ic/src/common/rest.rs#L621
+// https://forum.dfinity.org/t/pocketic-version-10-0-0-bootstrapping-system-canisters/57413?u=peterparker
+export const INCOMPLETE_STATE: IncompleteState = 'Enabled';

--- a/cli/src/services/pocket-ic/pocket-ic.services.ts
+++ b/cli/src/services/pocket-ic/pocket-ic.services.ts
@@ -11,6 +11,7 @@ import {
 import {readJunoConfig} from '../../configs/juno.config';
 import {
   ICP_CONFIG,
+  INCOMPLETE_STATE,
   INITIAL_TIME,
   INSTANCE_HTTP_GATEWAY,
   SUBNET_CONFIG
@@ -78,7 +79,8 @@ const buildInstanceConfig = async ({
     http_gateway_config: {
       ...INSTANCE_HTTP_GATEWAY,
       port: parseInt(port)
-    }
+    },
+    incomplete_state: INCOMPLETE_STATE
   };
 
   InstanceConfigSchema.parse(config);

--- a/cli/src/types/pocket-ic.ts
+++ b/cli/src/types/pocket-ic.ts
@@ -80,6 +80,8 @@ export const IcpFeaturesSchema = z.strictObject({
   nns_ui: zNullable(IcpFeatureSchema)
 });
 
+const IncompleteStateSchema = z.enum(['Disabled', 'Enabled']);
+
 export const InstanceConfigSchema = z.strictObject({
   subnet_config_set: ExtendedSubnetConfigSetSchema,
   http_gateway_config: zNullable(InstanceHttpGatewayConfigSchema),
@@ -88,7 +90,7 @@ export const InstanceConfigSchema = z.strictObject({
   log_level: zNullable(z.string()),
   bitcoind_addr: zNullable(z.array(SocketAddrSchema)),
   icp_features: zNullable(IcpFeaturesSchema),
-  incomplete_state: zNullable(z.enum(['Disabled', 'Enabled'])),
+  incomplete_state: zNullable(IncompleteStateSchema),
   initial_time: zNullable(InitialTimeSchema)
 });
 
@@ -99,3 +101,4 @@ export type IcpConfig = z.infer<typeof IcpConfigSchema>;
 export type IcpFeature = z.infer<typeof IcpFeatureSchema>;
 export type IcpFeatures = z.infer<typeof IcpFeaturesSchema>;
 export type InitialTime = z.infer<typeof InitialTimeSchema>;
+export type IncompleteState = z.infer<typeof IncompleteStateSchema>;


### PR DESCRIPTION
> I received two reports today of people ending up with corrupted state after doing X or Y, and I'm pretty sure there isn't much more I can do, since I never face the issue myself. So if such option exists, wondering if I should not start using it

> This option does exist, it is called incomplete_state in the payload to create a new PocketIC instance