### PR TITLE
feat: set inner CLI tsconfig moduleResolution to bundler

### DIFF
--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -6,7 +6,7 @@
     "strict": true,
     "noImplicitAny": false,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "outDir": "dist",
     "resolveJsonModule": true,
     "allowJs": true


### PR DESCRIPTION
We need to modernize the module resolution for the inner CLI to support libs with sub-entries.

This is required for #202.